### PR TITLE
Check for timebase once

### DIFF
--- a/scroll-latency.js
+++ b/scroll-latency.js
@@ -2,40 +2,35 @@ function $(id) { return document.getElementById(id); }
 
 var logElem = $('log');
 function log(msg) {
-    logElem.appendChild(document.createTextNode(msg));
-    logElem.appendChild(document.createElement('br'));
-    logElem.scrollTop = logElem.scrollHeight;
-}
-
-function timeNear(a, b) {
-  const d = 1000 * 60 * 5;
-  return a > b - d && a < b + d;
+  logElem.appendChild(document.createTextNode(msg));
+  logElem.appendChild(document.createElement('br'));
+  logElem.scrollTop = logElem.scrollHeight;
 }
 
 // Browsers (and the DOM spec) are in the process of moving the
 // event timestamp from being relative to Date.now() to being
 // relative to performance.now().
 
-var timebase;
-function checkTimebase(timeStamp)
-{
-    var newTimebase;
-    if ('performance' in window && timeNear(timeStamp, performance.now()))
-      newTimebase = "performance";
-    else if (timeNear(timeStamp, Date.now()))
-      newTimebase = "Date";
-    else {
-        log("ERROR: Unknown timebase for timeStamp: " + timeStamp);
-        return;
-    }
+// Detect timebase used for Event.timestamp
+var timebase = (function detectTimebase(testTimeStamp) {
+  function timeNear(a, b) {
+    const d = 1000 * 60 * 5;
+    return a > b - d && a < b + d;
+  }
 
-    if (!timebase) {
-      timebase = newTimebase;
-      log("Using timebase " + timebase + ".now()");
-    }
-    else if (timebase != newTimebase)
-      log("ERROR: Inconsistent timebase \"" + timebase + "\" for timeStamp: " + timeStamp);
-}
+  var timebase;
+  if ('performance' in window && timeNear(testTimeStamp, performance.now()))
+    timebase = "performance";
+  else if (timeNear(testTimeStamp, Date.now()))
+    timebase = "Date";
+  else {
+    log("ERROR: Unknown timebase for timeStamp: " + testTimeStamp);
+    return;
+  }
+
+  log("Using timebase " + timebase + ".now()");
+  return timebase;
+}(new Event('test').timeStamp));
 
 function round(val) {
   const scale = 1000;
@@ -43,7 +38,6 @@ function round(val) {
 }
 
 function handler(e) {
-  checkTimebase(e.timeStamp);
 
   // Only cancelable events block scrolling, and are the 
   // only ones that contribute to scroll latency.
@@ -51,11 +45,11 @@ function handler(e) {
     // Wait until after all event handlers have run (to capture
     // jank caused by slow handlers invoked after this one).
     requestAnimationFrame(function() {
-        // Compute the difference between the current time and the
-        // timestamp associated with the event.
-        var latency = window[timebase].now() - e.timeStamp;
-        log(e.type + ': ' + round(latency) + "ms" + 
-        (e.defaultPrevented ? ' defaultPrevented' : ''));
+      // Compute the difference between the current time and the
+      // timestamp associated with the event.
+      var latency = window[timebase].now() - e.timeStamp;
+      log(e.type + ': ' + round(latency) + "ms" + 
+      (e.defaultPrevented ? ' defaultPrevented' : ''));
     });
   }
 }
@@ -96,11 +90,11 @@ function doFrame() {
 doFrame();
 
 ['touchstart', 'touchmove', 'touchend', 'wheel'].forEach(function(type) {
-    // Note that today if this is the only touch/wheel listener on the page
-    // it can hurt scroll performance.  We use the EventListenerOptions polyfill
-    // here to make it clear we really want passive listeners to avoid this problem.
-    // See https://github.com/RByers/EventListenerOptions/blob/gh-pages/explainer.md
-   $('content').addEventListener(type, handler, {passive: true});
-   
-   $('content').addEventListener(type, jankHandler);
+  // Note that today if this is the only touch/wheel listener on the page
+  // it can hurt scroll performance.  We use the EventListenerOptions polyfill
+  // here to make it clear we really want passive listeners to avoid this problem.
+  // See https://github.com/RByers/EventListenerOptions/blob/gh-pages/explainer.md
+ $('content').addEventListener(type, handler, {passive: true});
+ 
+ $('content').addEventListener(type, jankHandler);
 });


### PR DESCRIPTION
All events should have the same type for timeStamp so it is enough to detect timebase once.
Furthermore the test may be done using a constructed event object as opposed to an actual input event.

Also some minor indentation correction.