### PR TITLE
Resize canvas correctly when handheld devices are rotated

### DIFF
--- a/paint.js
+++ b/paint.js
@@ -78,16 +78,16 @@ function InitializeCanvas() {
     var elem = document.getElementById("canvas");
 
     var newscale = window.devicePixelRatio ? window.devicePixelRatio : 1;
-    var newwidth = window.screen.width * newscale;
-    var newheight = window.screen.height * newscale;
+    var newwidth = window.innerWidth * newscale;
+    var newheight = window.innerHeight * newscale;
 
     if (elem.width != newwidth || elem.height != newheight || scale != newscale) {
         // resizing a canvas clears it, so do it only when it's dimensions have changed.
         scale = newscale;
         elem.width = newwidth;
         elem.height = newheight;
-        elem.style.width = window.screen.width + "px";
-        elem.style.height = window.screen.height + "px";
+        elem.style.width = window.innerWidth + "px";
+        elem.style.height = window.innerHeight + "px";
     }
 }
 


### PR DESCRIPTION
On handheld devices, such as tablets and phones, the window.screen.height and window.screen.width don't actually change (tested on an iPhone). This caused a third of the screen to be unresponsive, for example, when rotating from portrait mode to landscape mode.

The innerHeight and innerWidth properties need to be used instead as they change with the device's rotation. On rotation, because the canvas is resized, it will be cleared. However, this is already expected as noted in the comment that handles the canvas resizing.

Additionally, I tested on a regular laptop to ensure this did not break any functionality when the window was resized on non-handheld devices. Resizing the window will now clear the canvas as well, but as noted in the previous paragraph, I believe this is expected.